### PR TITLE
Fix for join_as restoring original body on stage change

### DIFF
--- a/DropInMultiplayerV2/Main.cs
+++ b/DropInMultiplayerV2/Main.cs
@@ -261,6 +261,7 @@ namespace DropInMultiplayer
             }
             else
             {
+                player.master.originalBodyPrefab = player.master.bodyPrefab;
                 Transform spawnTransform = GetSpawnTransformForPlayer(player);
                 player.master.Respawn(spawnTransform.position, spawnTransform.rotation);
             }


### PR DESCRIPTION
With AC Gearbox added `CharacterMaster.originalBodyPrefab` that used to store body that you chose in lobby, specifically so it can be restored on revives and scene changes. DropIn, when using `join_as` command only replaces `CharacterMaster.bodyPrefab`, which result in original body being restored on either death or scene change. This is not an issue for someone who just joins, because when body is spawned for the first time `originalBodyPrefab` is filled with `bodyPrefab`, however if you want to change body mid-run via the command, then you start encountering issues.