### PR TITLE
Fix null respawn, cleanup project build

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -343,3 +343,5 @@ ASALocalRun/
 # BeatPulse healthcheck temp database
 healthchecksdb
 
+# Output zip
+*.zip

--- a/DropInMultiplayerV2/CreatePackage.ps1
+++ b/DropInMultiplayerV2/CreatePackage.ps1
@@ -1,5 +1,0 @@
-$compress = @{
-	LiteralPath= ".\DropInMultiplayer.dll", ".\manifest.json", ".\icon.png", ".\README.md"
-	DestinationPath = "DropInMultiplayer.zip"
-}
-Compress-Archive -Force @compress

--- a/DropInMultiplayerV2/DropInMultiplayerV2.csproj
+++ b/DropInMultiplayerV2/DropInMultiplayerV2.csproj
@@ -1,73 +1,26 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
-<Project ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-  <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
+﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
-    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
-    <ProjectGuid>{0321A436-2C1F-4F7B-8A99-BECBBB8089D2}</ProjectGuid>
-    <OutputType>Library</OutputType>
-    <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>DropInMultiplayer</RootNamespace>
     <AssemblyName>DropInMultiplayer</AssemblyName>
-    <TargetFrameworkVersion>v4.7.2</TargetFrameworkVersion>
-    <FileAlignment>512</FileAlignment>
-    <Deterministic>true</Deterministic>
-  </PropertyGroup>
-  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
-    <DebugSymbols>true</DebugSymbols>
-    <DebugType>full</DebugType>
-    <Optimize>false</Optimize>
-    <OutputPath>bin\Debug\</OutputPath>
-    <DefineConstants>DEBUG;TRACE</DefineConstants>
-    <ErrorReport>prompt</ErrorReport>
-    <WarningLevel>4</WarningLevel>
-  </PropertyGroup>
-  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
-    <DebugType>pdbonly</DebugType>
-    <Optimize>true</Optimize>
-    <OutputPath>bin\Release\</OutputPath>
-    <DefineConstants>TRACE</DefineConstants>
-    <ErrorReport>prompt</ErrorReport>
-    <WarningLevel>4</WarningLevel>
+    <TargetFramework>netstandard2.1</TargetFramework>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+    <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="BepInEx">
-      <HintPath>..\Libraries\BepInEx.dll</HintPath>
-    </Reference>
-    <Reference Include="com.unity.multiplayer-hlapi.Runtime">
-      <HintPath>..\Libraries\com.unity.multiplayer-hlapi.Runtime.dll</HintPath>
-    </Reference>
-    <Reference Include="HGCSharpUtils">
-      <HintPath>..\Libraries\HGCSharpUtils.dll</HintPath>
-    </Reference>
-    <Reference Include="MMHOOK_RoR2">
-      <HintPath>..\Libraries\MMHOOK_RoR2.dll</HintPath>
-    </Reference>
-    <Reference Include="R2API.Core">
-      <HintPath>..\Libraries\R2API.Core.dll</HintPath>
-    </Reference>
-    <Reference Include="RoR2">
-      <HintPath>..\Libraries\RoR2.dll</HintPath>
-    </Reference>
-    <Reference Include="System" />
-    <Reference Include="System.Core" />
-    <Reference Include="Microsoft.CSharp" />
-    <Reference Include="UnityEngine">
-      <HintPath>..\Libraries\UnityEngine.dll</HintPath>
-    </Reference>
-    <Reference Include="UnityEngine.CoreModule, Version=0.0.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\Libraries\UnityEngine.CoreModule.dll</HintPath>
-    </Reference>
+    <PackageReference Include="BepInEx.Analyzers" Version="1.0.*">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+    <PackageReference Include="BepInEx.Core" Version="5.4.21" />
+
+    <PackageReference Include="R2API.Items" Version="1.0.*" />
+    <PackageReference Include="R2API.Language" Version="1.1.0" />
+
+    <PackageReference Include="UnityEngine.Modules" Version="6000.3.10" IncludeAssets="compile" />
+    <PackageReference Include="RiskOfRain2.GameLibs" Version="1.4.1.0-r.0" />
+    <PackageReference Include="MMHOOK.RoR2" Version="2025.12.9" NoWarn="NU1701" />
+    <PackageReference Include="Mono.Cecil" Version="0.11.*" />
   </ItemGroup>
-  <ItemGroup>
-    <Compile Include="DropInMultiplayerConfig.cs" />
-    <Compile Include="Helpers\BodyManager.cs" />
-    <Compile Include="Helpers\HelperExtensions.cs" />
-    <Compile Include="Main.cs" />
-    <Compile Include="Properties\AssemblyInfo.cs" />
-  </ItemGroup>
-  <ItemGroup />
   <ItemGroup>
     <None Include="manifest.json">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
@@ -75,17 +28,18 @@
     <None Include="README.md">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
-    <None Include="CreatePackage.ps1">
-      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
-    </None>
-  </ItemGroup>
-  <ItemGroup>
     <None Include="icon.png">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
   </ItemGroup>
-  <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
-  <PropertyGroup>
-    <PostBuildEvent>powershell .\CreatePackage.ps1</PostBuildEvent>
-  </PropertyGroup>
+  <!-- Only zip the release build -->
+  <Target Name="ZipOutputPath" AfterTargets="Build" Condition="'$(Configuration)' == 'Release'">
+    <ZipDirectory
+      SourceDirectory="$(OutputPath)"
+      DestinationFile="$(MSBuildProjectDirectory)\DropInMultiplayer.zip"
+      Overwrite="true" />
+  </Target>
+  <Target Name="CleanZip" AfterTargets="Clean">
+    <Delete Files="$(MSBuildProjectDirectory)\DropInMultiplayer.zip" />
+  </Target>
 </Project>

--- a/DropInMultiplayerV2/DropInMultiplayerV2.csproj
+++ b/DropInMultiplayerV2/DropInMultiplayerV2.csproj
@@ -5,6 +5,7 @@
     <TargetFramework>netstandard2.1</TargetFramework>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
+    <GenerateDependencyFile>false</GenerateDependencyFile>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="BepInEx.Analyzers" Version="1.0.*">

--- a/DropInMultiplayerV2/Main.cs
+++ b/DropInMultiplayerV2/Main.cs
@@ -252,7 +252,7 @@ namespace DropInMultiplayer
             JoinAsResult result = JoinAsResult.Success;
 
             bool isDead = player.GetCurrentBody() == null && player.master.lostBodyToDeath; // Dead and not remote operating a drone
-            isDead |= player.GetCurrentBody().isRemoteOp; // Dead and is remote operating a drone
+            isDead |= player.GetCurrentBody() != null && player.GetCurrentBody().isRemoteOp; // Dead and is remote operating a drone
 
             if (isDead && !DropInConfig.AllowRespawn.Value)
             {

--- a/nuget.config
+++ b/nuget.config
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+  <packageSources>
+    <add key="BepInEx" value="https://nuget.bepinex.dev/v3/index.json" />
+    <add key="nuget.org" value="https://api.nuget.org/v3/index.json" />
+  </packageSources>
+</configuration>


### PR DESCRIPTION
There's a null reference exception when you use /join_as to respawn after dying. The fix is essentially a one line change. However, to get this to build on Linux, I modernized the csproj and fixed the nuget dependencies.. The latter changes can be removed, but I was unable to get the build to work without them so I cannot test the one line change to Main.cs